### PR TITLE
feat: プラスアイコンコンポーネント作成 (Issue #24)

### DIFF
--- a/src/app/(authenticated)/travel-planning/components/PlusIcon.tsx
+++ b/src/app/(authenticated)/travel-planning/components/PlusIcon.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+/**
+ * PlusIconコンポーネントのProps
+ */
+interface PlusIconProps {
+    /** アイコンのサイズ（px） */
+    size?: number;
+}
+
+/**
+ * プラスアイコンコンポーネント
+ * CreatePlanFloatingButton専用のSVGアイコン
+ *
+ * @param size - アイコンのサイズ（デフォルト: 24px）
+ */
+const PlusIcon: React.FC<PlusIconProps> = ({ size = 24 }) => {
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+        >
+            <path
+                d="M12 5v14M5 12h14"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+};
+
+export default PlusIcon;


### PR DESCRIPTION
## 概要
Issue #24: プラスアイコンコンポーネント作成

## 実装内容
- ✅ PlusIconコンポーネントの作成 (`src/app/(authenticated)/travel-planning/components/PlusIcon.tsx`)
- ✅ SVGベースのプラスアイコン実装
- ✅ size propsのみ対応
- ✅ currentColorを使用してテキスト色を継承
- ✅ TypeScript型定義
- ✅ JSDoc コメント追加
- ✅ アクセシビリティ対応 (aria-hidden)

## 受け入れ基準確認
- ✅ TypeScript厳格な型定義（any型禁止）
- ✅ SVGベースの実装
- ✅ size propsのみ対応
- ✅ 関数コンポーネント使用
- ✅ デフォルトエクスポート
- ✅ currentColorを使用してテキスト色を継承

## 完了後の確認項目
- ✅ TypeScript型チェック成功
- ✅ ESLint警告なし
- ✅ Prettierフォーマット完了

## 関連Issue
Closes #24