### PR TITLE
test: 旅行プラン作成ボタンのテスト作成

### DIFF
--- a/src/app/(authenticated)/travel-planning/components/CreatePlanFloatingButton.test.tsx
+++ b/src/app/(authenticated)/travel-planning/components/CreatePlanFloatingButton.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import CreatePlanFloatingButton from "./CreatePlanFloatingButton";
+
+describe("CreatePlanFloatingButton", () => {
+    it("基本的なレンダリングができる", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // ボタンが表示される
+        const button = screen.getByRole("button");
+        expect(button).toBeInTheDocument();
+    });
+
+    it("正しいリンク遷移先が設定されている", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // リンクが/travel-plan/createを指している
+        const link = screen.getByRole("link");
+        expect(link).toHaveAttribute("href", "/travel-plan/create");
+    });
+
+    it("プラスアイコンが表示される", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // SVGアイコンが表示される
+        const icon = screen.getByRole("button").querySelector("svg");
+        expect(icon).toBeInTheDocument();
+    });
+
+    it("テキストが表示される", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // テキストが表示される
+        expect(screen.getByText("旅行プランを作成")).toBeInTheDocument();
+    });
+
+    it("レスポンシブ表示が適用されている（テキストがsm以上で表示）", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // テキストにhidden sm:inlineクラスが適用されている
+        const textElement = screen.getByText("旅行プランを作成");
+        expect(textElement).toHaveClass("hidden", "sm:inline");
+    });
+
+    it("既存Buttonコンポーネントのvariant=primaryが適用されている", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // ボタンにprimaryのスタイルが適用されている
+        const button = screen.getByRole("button");
+        expect(button).toHaveClass("bg-orange-500");
+    });
+
+    it("既存Buttonコンポーネントのsize=mediumが適用されている", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // ボタンにmediumサイズのスタイルが適用されている
+        const button = screen.getByRole("button");
+        expect(button).toHaveClass("py-3", "px-4", "text-base");
+    });
+
+    it("画面右下に固定配置されている", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // コンテナにfixed、bottom-6、right-6、z-50クラスが適用されている
+        const container = screen.getByRole("link").parentElement;
+        expect(container).toHaveClass("fixed", "bottom-6", "right-6", "z-50");
+    });
+
+    it("アクセシビリティ属性が適切に設定されている", () => {
+        render(<CreatePlanFloatingButton />);
+
+        // ボタンがアクセス可能
+        const button = screen.getByRole("button");
+        expect(button).toBeInTheDocument();
+
+        // リンクがアクセス可能
+        const link = screen.getByRole("link");
+        expect(link).toBeInTheDocument();
+
+        // SVGにaria-hidden属性が設定されている
+        const icon = button.querySelector("svg");
+        expect(icon).toHaveAttribute("aria-hidden", "true");
+    });
+});


### PR DESCRIPTION
## 概要
Issue #26 の対応

CreatePlanFloatingButtonコンポーネントの包括的なテストスイートを作成しました。

## 実装内容
- 9つのテストケースを実装
- 基本的なレンダリング確認
- リンク遷移先の確認
- プラスアイコンとテキストの表示確認
- レスポンシブ表示の確認
- Buttonコンポーネントのvariant/size適用確認
- 画面右下固定配置の確認
- アクセシビリティ属性の確認

## 確認済み項目
- [x] JestとReact Testing Libraryを使用
- [x] 全テストケースの実装
- [x] テストファイル命名規則に従っている
- [x] アクセシビリティテストの実装
- [x] レスポンシブ表示のテスト
- [x] 全テスト通過（9/9）
- [x] ESLint警告なし
- [x] Prettierフォーマット完了

## テスト結果


Closes #26